### PR TITLE
Add persistent config commands to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,44 @@ Don't forget to run the file:
 python red_team_llm.py
 ```
 
+### YAML Configuration & CLI
+
+Red teaming configurations can also be defined in YAML and executed via the new
+`deepteam` CLI:
+
+```yaml
+# examples/sample_red_team.yaml
+name: Run DeepTeam Penetration Testing
+target:
+  purpose: "To test the model's ability to generate code"
+  simulator_model: "gpt-3.5-turbo"
+  evaluation_model: "gpt-4"
+default_vulnerabilities:
+  - name: "Bias"
+    types: ["race"]
+attacks:
+  - name: "Prompt Injection"
+    weight: 2
+```
+
+Execute the run with:
+
+```bash
+deepteam run examples/sample_red_team.yaml
+```
+
+You can persist your OpenAI API key for repeated runs using the CLI:
+
+```bash
+deepteam login YOUR_OPENAI_API_KEY
+```
+
+To configure a local model instead, run:
+
+```bash
+deepteam set-local-model my-model --base-url http://localhost:8000
+```
+
 **Congratulations! You just succesfully completed your first red team ✅** Let's breakdown what happened.
 
 - The `model_callback` function is a wrapper around your LLM system and generates a `str` output based on a given `input`.

--- a/deepteam/cli/config.py
+++ b/deepteam/cli/config.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict
+
+CONFIG_FILE = Path.home() / ".deepteam" / "config.txt"
+
+
+def _read() -> Dict[str, str]:
+    if CONFIG_FILE.exists():
+        data: Dict[str, str] = {}
+        for line in CONFIG_FILE.read_text().splitlines():
+            key, _, value = line.partition("=")
+            if key:
+                data[key] = value
+        return data
+    return {}
+
+
+def _write(data: Dict[str, str]):
+    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text("\n".join(f"{k}={v}" for k, v in data.items()))
+
+
+def set_key(key: str, value: str):
+    data = _read()
+    data[key] = value
+    _write(data)
+
+
+def get_key(key: str) -> str | None:
+    return _read().get(key)
+
+
+def remove_key(key: str):
+    data = _read()
+    if key in data:
+        del data[key]
+        _write(data)
+
+
+def apply_env():
+    """Apply stored keys to os.environ."""
+    for k, v in _read().items():
+        os.environ.setdefault(k, v)

--- a/deepteam/cli/main.py
+++ b/deepteam/cli/main.py
@@ -1,0 +1,200 @@
+import yaml
+import typer
+
+from . import config
+
+from deepteam.red_teamer import RedTeamer
+from deepteam.vulnerabilities import (
+    Bias,
+    Toxicity,
+    Misinformation,
+    IllegalActivity,
+    PromptLeakage,
+    PIILeakage,
+    UnauthorizedAccess,
+    ExcessiveAgency,
+    Robustness,
+    IntellectualProperty,
+    Competition,
+    GraphicContent,
+    PersonalSafety,
+    CustomVulnerability,
+)
+from deepteam.attacks.single_turn import (
+    Base64,
+    GrayBox,
+    Leetspeak,
+    MathProblem,
+    Multilingual,
+    PromptInjection,
+    PromptProbing,
+    Roleplay,
+    ROT13,
+)
+from deepteam.attacks.multi_turn import (
+    CrescendoJailbreaking,
+    LinearJailbreaking,
+    TreeJailbreaking,
+    SequentialJailbreak,
+    BadLikertJudge,
+)
+
+app = typer.Typer(name="deepteam")
+
+VULN_CLASSES = [
+    Bias,
+    Toxicity,
+    Misinformation,
+    IllegalActivity,
+    PromptLeakage,
+    PIILeakage,
+    UnauthorizedAccess,
+    ExcessiveAgency,
+    Robustness,
+    IntellectualProperty,
+    Competition,
+    GraphicContent,
+    PersonalSafety,
+]
+VULN_MAP = {cls().get_name(): cls for cls in VULN_CLASSES}
+
+ATTACK_CLASSES = [
+    Base64,
+    GrayBox,
+    Leetspeak,
+    MathProblem,
+    Multilingual,
+    PromptInjection,
+    PromptProbing,
+    Roleplay,
+    ROT13,
+    CrescendoJailbreaking,
+    LinearJailbreaking,
+    TreeJailbreaking,
+    SequentialJailbreak,
+    BadLikertJudge,
+]
+ATTACK_MAP = {cls().get_name(): cls for cls in ATTACK_CLASSES}
+
+
+def _build_vulnerability(cfg: dict):
+    name = cfg.get("name")
+    if not name:
+        raise ValueError("Vulnerability entry missing 'name'")
+    if name == "CustomVulnerability":
+        return CustomVulnerability(
+            name=cfg.get("custom_name", "Custom"),
+            types=cfg.get("types"),
+            custom_prompt=cfg.get("prompt"),
+        )
+    cls = VULN_MAP.get(name)
+    if not cls:
+        raise ValueError(f"Unknown vulnerability: {name}")
+    return cls(types=cfg.get("types"))
+
+
+def _build_attack(cfg: dict):
+    name = cfg.get("name")
+    if not name:
+        raise ValueError("Attack entry missing 'name'")
+    cls = ATTACK_MAP.get(name)
+    if not cls:
+        raise ValueError(f"Unknown attack: {name}")
+    kwargs = {}
+    if "weight" in cfg:
+        kwargs["weight"] = cfg["weight"]
+    if "type" in cfg:
+        kwargs["type"] = cfg["type"]
+    if "persona" in cfg:
+        kwargs["persona"] = cfg["persona"]
+    if "category" in cfg:
+        kwargs["category"] = cfg["category"]
+    if "turns" in cfg:
+        kwargs["turns"] = cfg["turns"]
+    if "enable_refinement" in cfg:
+        kwargs["enable_refinement"] = cfg["enable_refinement"]
+    return cls(**kwargs)
+
+
+def _load_config(path: str):
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+async def _echo_callback(input: str) -> str:
+    return input
+
+
+@app.command()
+def run(config: str):
+    """Run a red teaming execution based on a YAML configuration"""
+    cfg = _load_config(config)
+    config.apply_env()
+
+    target = cfg.get("target", {})
+    red_teamer = RedTeamer(
+        simulator_model=target.get("simulator_model", "gpt-3.5-turbo-0125"),
+        evaluation_model=target.get("evaluation_model", "gpt-4o"),
+        target_purpose=target.get("purpose", ""),
+        async_mode=cfg.get("options", {}).get("run_async", True),
+        max_concurrent=cfg.get("options", {}).get("max_concurrent", 10),
+    )
+
+    vulnerabilities_cfg = cfg.get("default_vulnerabilities", [])
+    vulnerabilities_cfg += cfg.get("custom_vulnerabilities", [])
+    vulnerabilities = [_build_vulnerability(v) for v in vulnerabilities_cfg]
+
+    attacks = [_build_attack(a) for a in cfg.get("attacks", [])]
+
+    risk = red_teamer.red_team(
+        model_callback=_echo_callback,
+        vulnerabilities=vulnerabilities,
+        attacks=attacks,
+        attacks_per_vulnerability_type=cfg.get("options", {}).get(
+            "attacks_per_vulnerability_type", 1
+        ),
+        ignore_errors=cfg.get("options", {}).get("ignore_errors", False),
+    )
+
+    red_teamer._print_risk_assessment()
+    return risk
+
+
+@app.command()
+def login(api_key: str = typer.Argument(..., help="OpenAI API Key")):
+    """Store API key for later runs."""
+    config.set_key("OPENAI_API_KEY", api_key)
+    typer.echo("API key saved.")
+
+
+@app.command()
+def logout():
+    """Remove stored API key."""
+    config.remove_key("OPENAI_API_KEY")
+    typer.echo("Logged out.")
+
+
+@app.command("set-local-model")
+def set_local_model(
+    model_name: str = typer.Argument(...),
+    base_url: str = typer.Option(..., "--base-url"),
+    api_key: str = typer.Option(None, "--api-key"),
+):
+    """Configure a local model endpoint."""
+    config.set_key("LOCAL_MODEL_NAME", model_name)
+    config.set_key("LOCAL_MODEL_BASE_URL", base_url)
+    if api_key:
+        config.set_key("LOCAL_MODEL_API_KEY", api_key)
+    typer.echo("Local model configured.")
+
+
+@app.command("unset-local-model")
+def unset_local_model():
+    """Remove local model configuration."""
+    config.remove_key("LOCAL_MODEL_NAME")
+    config.remove_key("LOCAL_MODEL_BASE_URL")
+    config.remove_key("LOCAL_MODEL_API_KEY")
+    typer.echo("Local model unset.")
+
+if __name__ == "__main__":
+    app()

--- a/examples/sample_red_team.yaml
+++ b/examples/sample_red_team.yaml
@@ -1,0 +1,29 @@
+name: Run DeepTeam Penetration Testing
+
+target:
+  purpose: "To test the model's ability to generate code"
+  simulator_model: "gpt-3.5-turbo"
+  evaluation_model: "gpt-4"
+
+default_vulnerabilities:
+  - name: "Bias"
+    types: ["race"]
+
+custom_vulnerabilities:
+  - name: "CustomVulnerability"
+    custom_name: "Business Logic"
+    types: ["access_control", "privilege_escalation"]
+    prompt: |
+      I want you to act as a security expert. Based on the purpose, please create a list of exploits.
+
+attacks:
+  - name: "Prompt Injection"
+    weight: 2
+  - name: "ROT-13"
+    weight: 1
+
+options:
+  attacks_per_vulnerability_type: 1
+  ignore_errors: true
+  run_async: true
+  max_concurrent: 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,16 @@ dependencies = [
     "requests>=2.31.0",
     "tabulate>=0.9.0",
     "tqdm>=4.66.1",
+    "pyyaml>=6.0",
 ]
 
 [project.urls]
 Repository = "https://github.com/confident-ai/deepteam"
 Documentation = "https://trydeepteam.com"
 Issues = "https://github.com/confident-ai/deepteam/issues"
+
+[project.scripts]
+deepteam = "deepteam.cli.main:app"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,19 @@
+import os
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "config", Path(__file__).resolve().parents[1] / "deepteam/cli/config.py"
+)
+config = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(config)
+
+
+def test_config_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "cfg")
+    config.set_key("TEST_KEY", "1")
+    assert config.get_key("TEST_KEY") == "1"
+    config.apply_env()
+    assert os.environ.get("TEST_KEY") == "1"
+    config.remove_key("TEST_KEY")
+    assert config.get_key("TEST_KEY") is None

--- a/tests/test_cli_yaml.py
+++ b/tests/test_cli_yaml.py
@@ -1,0 +1,15 @@
+from deepteam.cli import main as cli
+
+sample = {
+    "target": {"purpose": "t"},
+    "default_vulnerabilities": [{"name": "Bias", "types": ["race"]}],
+    "attacks": [{"name": "Prompt Injection", "weight": 1}],
+}
+
+
+def test_build_objects():
+    vulns = [cli._build_vulnerability(v) for v in sample["default_vulnerabilities"]]
+    attacks = [cli._build_attack(a) for a in sample["attacks"]]
+    assert vulns[0].get_name() == "Bias"
+    assert attacks[0].get_name() == "Prompt Injection"
+


### PR DESCRIPTION
## Summary
- extend `deepteam` CLI with commands for storing OpenAI keys and local model settings
- apply stored configuration when running YAML configs
- document new CLI commands in README
- implement simple config helper module
- test config helper

## Testing
- `pytest tests/test_cli_config.py -q`
- `pytest -q` *(fails: missing deepeval)*

------
https://chatgpt.com/codex/tasks/task_e_6847bffaf6b88325a88ec660e10286f2